### PR TITLE
fix: Fixing the bug in database-migrator about the error of SSL connection

### DIFF
--- a/pkg/config/bootstrap.go
+++ b/pkg/config/bootstrap.go
@@ -29,6 +29,7 @@ func RegistDatabaseFlags(flag *pflag.FlagSet) {
 	flag.String("db-user", "", "database user,\ncan set by environment DB_USER")
 	flag.String("db-password", "", "database password,\ncan set by environment DB_PASSWORD")
 	flag.String("db-password-file", "", "database password file, if db-password is set, this will be ignored,\ncan set by environment DB_PASSWORD_FILE")
+	flag.String("db-name", "postgres", "database name,\ncan set by environment DB_DATABASE")
 	flag.Bool("db-use-ssl", false, "use ssl to connect database,\ncan set by environment DB_USE_SSL")
 
 	viper.BindPFlag("db.host", flag.Lookup("db-host"))
@@ -36,6 +37,7 @@ func RegistDatabaseFlags(flag *pflag.FlagSet) {
 	viper.BindPFlag("db.user", flag.Lookup("db-user"))
 	viper.BindPFlag("db.password", flag.Lookup("db-password"))
 	viper.BindPFlag("db.password-file", flag.Lookup("db-password-file"))
+	viper.BindPFlag("db.database", flag.Lookup("db-name"))
 	viper.BindPFlag("db.use-ssl", flag.Lookup("db-use-ssl"))
 
 	viper.BindEnv("db.host", "DB_HOST")
@@ -43,6 +45,7 @@ func RegistDatabaseFlags(flag *pflag.FlagSet) {
 	viper.BindEnv("db.user", "DB_USER")
 	viper.BindEnv("db.password", "DB_PASSWORD")
 	viper.BindEnv("db.password-file", "DB_PASSWORD_FILE")
+	viper.BindEnv("db.database", "DB_DATABASE")
 	viper.BindEnv("db.use-ssl", "DB_USE_SSL")
 }
 


### PR DESCRIPTION
fix: Add the missing "dbname" flag in bootstrap.go, ensuring that when running the database-migrator, no connection error occurs due to the SSL mode not being disabled.
@a2ure123

<img width="2355" height="1390" alt="migra1" src="https://github.com/user-attachments/assets/efd4fa66-0451-4ace-bc77-7561f40dfeaf" />
<img width="2245" height="1284" alt="migra2" src="https://github.com/user-attachments/assets/f4fdcef9-7d2f-4564-8576-cec5a40f76ff" />
<img width="1456" height="763" alt="ssl-error" src="https://github.com/user-attachments/assets/55a161bc-2827-4d97-9954-9a175b826973" />
